### PR TITLE
fix(build): Resolve final TypeScript error in server module

### DIFF
--- a/src/router/server.ts
+++ b/src/router/server.ts
@@ -1,4 +1,4 @@
-import { Server } from "@musistudio/llms";
+import Server = require("@musistudio/llms");
 import { readConfigFile, writeConfigFile, backupConfigFile } from "./utils";
 import { join } from "path";
 import * as vscode from 'vscode';


### PR DESCRIPTION
The last remaining build error was `TS2709: Cannot use namespace 'Server' as a type`.

This was caused by an incorrect import statement for the `@musistudio/llms` package. The package seems to use a CommonJS export structure for its `Server` class.

This commit changes the import syntax from ES6 `import { Server } from ...` to the CommonJS-compatible `import Server = require(...)` in `src/router/server.ts`.

This should resolve the final build error and allow the extension to be packaged successfully.