### PR TITLE
fix: Correct command registration and help link

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,6 +16,7 @@ import { UpdateChecker } from './utils/updateChecker';
 import { PermissionManager } from './features/permission/permissionManager';
 import { NotificationUtils } from './utils/notificationUtils';
 import { SpecTaskCodeLensProvider } from './providers/specTaskCodeLensProvider';
+import { CcrSettingsWebview } from './features/ccr/ccrSettingsWebview';
 
 let claudeCodeProvider: ClaudeCodeProvider;
 let specManager: SpecManager;
@@ -425,9 +426,14 @@ function registerCommands(context: vscode.ExtensionContext, specExplorer: SpecEx
             await vscode.window.showTextDocument(document);
         }),
 
+        vscode.commands.registerCommand('spec-ai-coder.ccr.openSettings', () => {
+            CcrSettingsWebview.createOrShow(context.extensionUri);
+        }),
+
         vscode.commands.registerCommand('spec-ai-coder.help.open', async () => {
             outputChannel.appendLine('Opening help...');
-            const helpUrl = 'https://github.com/notdp/kiro-for-cc#readme';
+            // TODO: The user should replace this with their forked repository URL
+            const helpUrl = 'https://github.com/abusallam/kiro-for-cc#readme';
             vscode.env.openExternal(vscode.Uri.parse(helpUrl));
         }),
 


### PR DESCRIPTION
This commit addresses two issues found during user testing:

1.  **Register `openSettings` command:** The `spec-ai-coder.ccr.openSettings` command was missing from the `registerCommands` function in `extension.ts`. This caused the "Open Router Settings" link to be unresponsive. The command is now correctly registered.

2.  **Update Help URL:** The help link was hardcoded to point to the original upstream repository. It has been updated to point to the user's forked repository.